### PR TITLE
Fix #4 Use ' ', Add equal

### DIFF
--- a/letters.rb
+++ b/letters.rb
@@ -24,6 +24,7 @@ def draw(str)
         when "." then key = :period
         when "-" then key = :hyphen
         when "+" then key = :plus
+		when "=" then key = :equal
         when "_" then key = :underscore
         when "@" then key = :at
         when "#" then key = :hash
@@ -329,6 +330,15 @@ plus.contents[3] =  " |__  __| "
 plus.contents[4] =  "   |__|   "
 plus.contents[5] =  "          "
 BlockLetterMap[:plus] = plus
+
+equal = NewBlockLetter.new
+equal.contents[0] =  "          "
+equal.contents[1] =  "          "
+equal.contents[2] =  " ________ "
+equal.contents[3] =  " ________ "
+equal.contents[4] =  "          "
+equal.contents[5] =  "          "
+BlockLetterMap[:equal] = equal
 
 underscore = NewBlockLetter.new
 underscore.contents[0] =  "        "


### PR DESCRIPTION
The exclamation mark is part of history expansion in bash. To use it you need it enclosed in single quotes '  ' 
Enclosing the exclamation along with other text in single quotes (' ') instead of double quotes (" ") will not give the ```-bash:  !: event not found``` error.
The equals sign was also added.